### PR TITLE
fix Contract deserialize function

### DIFF
--- a/src/smartcontract/token.ts
+++ b/src/smartcontract/token.ts
@@ -168,7 +168,7 @@ export class Contract {
         const args = sr.readNextBytes()
         c.version = version
         c.address = address
-        c.method = method
+        c.method = hexstr2str(method)
         c.args = args
         return c
     }


### PR DESCRIPTION
Hello,

deserialize function on Contract is not the opposite of serialize and therefore If I deserialize data from the blockchain I get "7472616e73666572" instead of "transfer".