### PR TITLE
fix readNextBytes method in StringReader helper class

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -195,7 +195,10 @@ export class StringReader {
 	 * @return {string}
 	 */
 	readNextBytes() {
-		return this.read(this.readNextLen())
+		const bytesToRead = this.readNextLen();
+		if (bytesToRead === 0) return '';
+
+		return this.read(bytesToRead);
 	}
 
 	/**


### PR DESCRIPTION
Hello,

In case of reading 0 next bytes, the method failed, because there is error thrown in subsequent read method for end of string.

I came across this when trying to decode "init" contracts for ONT. (transaction 476a15e30208e84dd5307e4fc3c8c268650e88c1b44f96741053bf63d23cd023)