### PR TITLE
change to canonical ECDSA sign mode, Signable interface, Transfer class

### DIFF
--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -255,7 +255,7 @@ export class PrivateKey extends Key {
      */
     computeEcDSASignature(hash: string): string {
         const ec = new elliptic.ec(this.parameters.curve.preset);
-        const signed = ec.sign(hash, this.key, null);
+        const signed = ec.sign(hash, this.key, { canonical: true });
         return Buffer.concat([
             signed.r.toArrayLike(Buffer, 'be', 32),
             signed.s.toArrayLike(Buffer, 'be', 32)

--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -29,8 +29,10 @@ import { Address } from './address';
 import { Key, KeyParameters } from './Key';
 import { KeyType } from './KeyType';
 import { PublicKey } from './PublicKey';
+import { Signable } from './signable';
 import { Signature } from './Signature';
 import { SignatureScheme } from './SignatureScheme';
+
 // tslint:disable-next-line:no-var-requires
 const HDKey = require('@ont-community/hdkey-secp256r1');
 
@@ -94,17 +96,22 @@ export class PrivateKey extends Key {
      *
      * This method is not suitable, if external keys (Ledger, TPM, ...) support is required.
      *
-     * @param msg Hex encoded input data
+     * @param msg Hex encoded input data or Signable object
      * @param schema Signing schema to use
      * @param publicKeyId Id of public key
      */
-    sign(msg: string, schema?: SignatureScheme, publicKeyId?: string): Signature {
+    sign(msg: string | Signable, schema?: SignatureScheme, publicKeyId?: string): Signature {
         if (schema === undefined) {
             schema = this.algorithm.defaultSchema;
         }
 
         if (!this.isSchemaSupported(schema)) {
             throw new Error('Signature schema does not match key type.');
+        }
+
+        // retrieves content to sign if not provided directly
+        if (typeof msg !== 'string') {
+            msg = msg.getSignContent();
         }
 
         let hash: string;
@@ -126,11 +133,11 @@ export class PrivateKey extends Key {
      *
      * This method is suitable, if external keys (Ledger, TPM, ...) support is required.
      *
-     * @param msg Hex encoded input data
+     * @param msg Hex encoded input data or Signable object
      * @param schema Signing schema to use
      * @param publicKeyId Id of public key
      */
-    async signAsync(msg: string, schema?: SignatureScheme, publicKeyId?: string): Promise<Signature> {
+    async signAsync(msg: string | Signable, schema?: SignatureScheme, publicKeyId?: string): Promise<Signature> {
         return this.sign(msg, schema, publicKeyId);
     }
 

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -23,6 +23,7 @@ import { hexstr2str, hexstring2ab, num2hexstring, StringReader } from '../utils'
 import { CurveLabel } from './CurveLabel';
 import { Key, KeyParameters } from './Key';
 import { KeyType } from './KeyType';
+import { Signable } from './signable';
 import { Signature } from './Signature';
 import { SignatureScheme } from './SignatureScheme';
 
@@ -60,12 +61,17 @@ export class PublicKey extends Key {
      * Verifies if the signature was created with private key corresponding to supplied public key
      * and was not tampered with using signature schema.
      *
-     * @param msg Hex encoded input data
+     * @param msg Hex encoded input data or Signable object
      * @param signature Signature object
      */
-    verify(msg: string, signature: Signature): boolean {
+    verify(msg: string | Signable, signature: Signature): boolean {
         if (!this.isSchemaSupported(signature.algorithm)) {
             throw new Error('Signature schema does not match key type.');
+        }
+
+        // retrieves content to sign if not provided directly
+        if (typeof msg !== 'string') {
+            msg = msg.getSignContent();
         }
 
         let hash: string;

--- a/src/crypto/signable.ts
+++ b/src/crypto/signable.ts
@@ -16,13 +16,12 @@
  * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export { Address } from './address';
-export { KeyType } from './KeyType';
-export { CurveLabel } from './CurveLabel';
-export { SignatureScheme } from './SignatureScheme';
-export { KeyParameters, JsonKeyParameters, JsonKey } from './Key';
-export { PrivateKey } from './PrivateKey';
-export { KeyDeserializer, registerKeyDeserializer } from './PrivateKeyFactory';
-export { PublicKey, PublicKeyStatus } from './PublicKey';
-export { Signature, PgpSignature } from './Signature';
-export { Signable } from './signable';
+/**
+ * Interface for other classes to implement, which should be signable.
+ */
+export interface Signable {
+    /**
+     * Get the sign content of object
+     */
+    getSignContent(): string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { DDO, DDOAttribute } from './transaction/ddo';
 import * as ScriptBuilder from './transaction/scriptBuilder';
 import { Transaction } from './transaction/transaction';
 import * as TransactionBuilder from './transaction/transactionBuilder';
+import { Transfer } from './transaction/transfer';
 import { TxSignature } from './transaction/txSignature';
 import * as utils from './utils';
 import { Wallet } from './wallet';
@@ -49,6 +50,7 @@ class ONT {
     DDO: any;
     DDOAttribute: any;
     Transaction: any;
+    Transfer: any;
     TxSignature: any;
     TransactionBuilder: any;
     OntAssetTxBuilder: any;
@@ -78,6 +80,7 @@ class ONT {
         this.DDO = DDO;
         this.DDOAttribute = DDOAttribute;
         this.Transaction = Transaction;
+        this.Transfer = Transfer;
         this.TxSignature = TxSignature;
         this.TransactionBuilder = TransactionBuilder;
         this.OntAssetTxBuilder = OntAssetTxBuilder;
@@ -126,6 +129,7 @@ export {
     DDO,
     DDOAttribute,
     Transaction,
+    Transfer,
     TxSignature,
     Parameter,
     ParameterType,

--- a/src/network/websocket/websocketSender.ts
+++ b/src/network/websocket/websocketSender.ts
@@ -53,6 +53,13 @@ export class WebsocketSender {
             }
         });
 
+        this.wsp.onClose.addListener(() => {
+            if (this.debug) {
+                // tslint:disable-next-line:no-console
+                console.log('disconnected');
+            }
+        });
+
         this.wsp.onSend.addListener((message: any) => {
             if (this.debug) {
                 // tslint:disable-next-line:no-console

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -754,7 +754,7 @@ export class SDK {
             error: ERROR_CODE.SUCCESS,
             result: '',
             tx: tx.serialize(),
-            txHash: reverseHex(tx.getHash())
+            txHash: reverseHex(tx.getSignContent())
         };
         callback && sendBackResult2Native(JSON.stringify(result), callback);
         // clear privateKey and password
@@ -810,7 +810,7 @@ export class SDK {
             error: ERROR_CODE.SUCCESS,
             result: '',
             tx: tx.serialize(),
-            txHash: reverseHex(tx.getHash())
+            txHash: reverseHex(tx.getSignContent())
         };
         callback && sendBackResult2Native(JSON.stringify(result), callback);
         // clear privateKey and password
@@ -1171,7 +1171,7 @@ export class SDK {
         tx.payer = fromAddress;
         const result = {
             error: ERROR_CODE.SUCCESS,
-            txHash: reverseHex(tx.getHash()),
+            txHash: reverseHex(tx.getSignContent()),
             txData: tx.serialize()
         };
         callback && sendBackResult2Native(JSON.stringify(result), callback);

--- a/src/smartcontract/nativevm/ontAssetTxBuilder.ts
+++ b/src/smartcontract/nativevm/ontAssetTxBuilder.ts
@@ -20,6 +20,7 @@ import { TOKEN_TYPE } from '../../consts';
 import { Address } from '../../crypto';
 import { ERROR_CODE } from '../../error';
 import { Transaction } from '../../transaction/transaction';
+import { Transfer } from '../../transaction/transfer';
 import { hex2VarBytes } from '../../utils';
 import { makeNativeContractTx } from './../../transaction/transactionBuilder';
 import { buildNativeCodeScript } from './../abi/nativeVmParamsBuilder';
@@ -72,7 +73,7 @@ export function makeTransferTx(
     gasPrice: string,
     gasLimit: string,
     payer?: Address
-): Transaction {
+): Transfer {
     amount = Number(amount);
     verifyAmount(amount);
     const struct = new Struct();
@@ -81,7 +82,12 @@ export function makeTransferTx(
     list.push([struct]);
     const contract = getTokenContract(tokenType);
     const params = buildNativeCodeScript(list);
-    const tx = makeNativeContractTx('transfer', params, contract, gasPrice, gasLimit);
+    const tx: Transfer = makeNativeContractTx('transfer', params, contract, gasPrice, gasLimit) as any;
+    tx.tokenType = tokenType;
+    tx.from = from;
+    tx.to = to;
+    tx.amount = amount;
+
     if (payer) {
         tx.payer = payer;
     } else {

--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -19,6 +19,7 @@
 import * as cryptoJS from 'crypto-js';
 import Fixed64 from '../common/fixed64';
 import { Address } from '../crypto/address';
+import { Signable } from '../crypto/signable';
 import { ab2hexstring, generateRandomArray, num2hexstring, StringReader } from '../utils';
 import DeployCode from './payload/deployCode';
 import InvokeCode from './payload/invokeCode';
@@ -70,7 +71,7 @@ export class Fee {
     }
 }
 
-export class Transaction {
+export class Transaction implements Signable {
     static deserialize(hexstring: string): Transaction {
         const tx = new Transaction();
 
@@ -231,9 +232,9 @@ export class Transaction {
     }
 
     /**
-     * Get the hash of transaction
+     * Get the signable content
      */
-    getHash() {
+    getSignContent() {
         const data = this.serializeUnsignedData();
 
         const ProgramHexString = cryptoJS.enc.Hex.parse(data);
@@ -241,5 +242,13 @@ export class Transaction {
         const ProgramSha2562 = cryptoJS.SHA256(cryptoJS.enc.Hex.parse(ProgramSha256)).toString();
 
         return ProgramSha2562;
+    }
+
+    /**
+     * Get the hash of transaction
+     * @deprecated Use getSignContent instead
+     */
+    getHash() {
+        return this.getSignContent();
     }
 }

--- a/src/transaction/transactionBuilder.ts
+++ b/src/transaction/transactionBuilder.ts
@@ -52,9 +52,7 @@ export const Default_params = {
  * @param schema Signature Schema to use
  */
 export const signTransaction = (tx: Transaction, privateKey: PrivateKey, schema?: SignatureScheme) => {
-    const hash = tx.getHash();
-
-    const signature = TxSignature.create(hash, privateKey, schema);
+    const signature = TxSignature.create(tx, privateKey, schema);
 
     tx.sigs = [signature];
 };
@@ -70,9 +68,7 @@ export const signTransaction = (tx: Transaction, privateKey: PrivateKey, schema?
  * @param schema Signature Schema to use
  */
 export const signTransactionAsync = async (tx: Transaction, privateKey: PrivateKey, schema?: SignatureScheme) => {
-    const hash = tx.getHash();
-
-    const signature = await TxSignature.createAsync(hash, privateKey, schema);
+    const signature = await TxSignature.createAsync(tx, privateKey, schema);
 
     tx.sigs = [signature];
 };
@@ -88,8 +84,7 @@ export const signTransactionAsync = async (tx: Transaction, privateKey: PrivateK
  * @param schema Signature Schema to use
  */
 export const addSign = (tx: Transaction, privateKey: PrivateKey, schema?: SignatureScheme) => {
-    const hash = tx.getHash();
-    const signature = TxSignature.create(hash, privateKey, schema);
+    const signature = TxSignature.create(tx, privateKey, schema);
 
     tx.sigs.push(signature);
 };
@@ -121,7 +116,7 @@ export const signTx = (tx: Transaction, M: number, pubKeys: PublicKey[],
                 if (tx.sigs[i].sigData.length + 1 > pubKeys.length) {
                     throw new Error('Too many sigData');
                 }
-                const signData = privateKey.sign(tx.getHash(), scheme).serializeHex();
+                const signData = privateKey.sign(tx, scheme).serializeHex();
                 tx.sigs[i].sigData.push(signData);
                 return;
             }
@@ -130,7 +125,7 @@ export const signTx = (tx: Transaction, M: number, pubKeys: PublicKey[],
     const sig = new TxSignature();
     sig.M = M;
     sig.pubKeys = pubKeys;
-    sig.sigData = [privateKey.sign(tx.getHash(), scheme).serializeHex()];
+    sig.sigData = [privateKey.sign(tx, scheme).serializeHex()];
     tx.sigs.push(sig);
 };
 

--- a/src/transaction/transactionBuilder.ts
+++ b/src/transaction/transactionBuilder.ts
@@ -30,6 +30,7 @@ import DeployCode from './payload/deployCode';
 import InvokeCode from './payload/invokeCode';
 import { buildSmartContractParam, pushHexString, pushInt } from './scriptBuilder';
 import { Transaction, TxType } from './transaction';
+import { Transfer } from './transfer';
 import { TxSignature } from './txSignature';
 // const abiInfo = AbiInfo.parseJson(JSON.stringify(json));
 
@@ -155,7 +156,14 @@ export function makeNativeContractTx(
     code += pushHexString(str2hexstr(NATIVE_INVOKE_NAME));
     const payload = new InvokeCode();
     payload.code = code;
-    const tx = new Transaction();
+
+    let tx: Transaction;
+    if (funcName === 'transfer') {
+        tx = new Transfer();
+    } else {
+        tx = new Transaction();
+    }
+
     tx.type = TxType.Invoke;
     tx.payload = payload;
     if (gasLimit) {

--- a/src/transaction/transfer.ts
+++ b/src/transaction/transfer.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Address } from '../crypto/address';
+import { Transaction } from './transaction';
+
+export class Transfer extends Transaction {
+    amount: number | string;
+    tokenType: string;
+    from: Address;
+    to: Address;
+}

--- a/src/transaction/txSignature.ts
+++ b/src/transaction/txSignature.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { PrivateKey, PublicKey, SignatureScheme } from '../crypto';
+import { PrivateKey, PublicKey, Signable, SignatureScheme } from '../crypto';
 import { hex2VarBytes, StringReader } from '../utils';
 import { getParamsFromProgram, getProgramInfo,
     programFromMultiPubKey, programFromParams, programFromPubKey } from './program';
@@ -64,11 +64,11 @@ export class TxSignature {
      *
      * If the signature schemas is not provided, the default schemes for the key types are used.
      *
-     * @param hash hash of the transaction
+     * @param hash hash of the transaction or signable transaction
      * @param privateKey Private key to use
      * @param scheme Signature scheme to use
      */
-    static create(hash: string, privateKey: PrivateKey, scheme?: SignatureScheme) {
+    static create(hash: string | Signable, privateKey: PrivateKey, scheme?: SignatureScheme) {
         const signature = new TxSignature();
 
         signature.M = 1;
@@ -83,11 +83,11 @@ export class TxSignature {
      *
      * If the signature schemas is not provided, the default schemes for the key types are used.
      *
-     * @param hash hash of the transaction
+     * @param hash hash of the transaction or signable transaction
      * @param privateKey Private key to use
      * @param scheme Signature scheme to use
      */
-    static async createAsync(hash: string, privateKey: PrivateKey, scheme?: SignatureScheme) {
+    static async createAsync(hash: string | Signable, privateKey: PrivateKey, scheme?: SignatureScheme) {
         const signature = new TxSignature();
 
         signature.M = 1;

--- a/test/transfer.sign.test.ts
+++ b/test/transfer.sign.test.ts
@@ -1,0 +1,49 @@
+/*
+* Copyright (C) 2018 The ontology Authors
+* This file is part of The ontology library.
+*
+* The ontology is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* The ontology is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Address, PrivateKey, Signature, SignatureScheme } from '../src/crypto';
+import { makeTransferTx } from '../src/smartcontract/nativevm/ontAssetTxBuilder';
+import { signTransaction } from './../src/transaction/transactionBuilder';
+
+// tslint:disable:no-console
+// tslint:disable:max-line-length
+// tslint:disable:quotemark
+describe('test transfer sign', () => {
+    test('test canonical sign', async () => {
+        const mnemonics = 'immune annual decorate major humble surprise dismiss trend edit suit alert uncover release transfer suit torch small timber lock mind tomorrow north lend diet';
+        const privateKey = PrivateKey.generateFromMnemonic(mnemonics, "m/44'/888'/0'/0/0");
+        const publicKey = privateKey.getPublicKey();
+        const address = Address.fromPubKey(publicKey);
+
+        const from = new Address('AGn8JFPGM5S4jkWhTC89Xtz1Y76sPz29Rc');
+        const to = new Address('AcyLq3tokVpkMBMLALVMWRdVJ83TTgBUwU');
+        const tx = makeTransferTx('ONG', from, to, 12000000, '500', '30000');
+        tx.nonce = 'eb1c7f7f';
+        signTransaction(tx, privateKey);
+
+        console.log(tx);
+        console.log('hash', tx.getHash());
+        console.log('key ', privateKey.key);
+        console.log('pub ', publicKey.key);
+        console.log('sig ', tx.sigs[0].sigData[0]);
+
+        // if canonical mode is not set, the result will be
+        // 017da1b8268e1272d7471eef58fa0884108073c09d5efdae0143da5d281019682ea5ea9d0d289b7b15fc861c01418fda56642be628560fe4d7ccdede930e620b5d
+        expect(tx.sigs[0].sigData[0]).toBe('017da1b8268e1272d7471eef58fa0884108073c09d5efdae0143da5d281019682e5a1562f1d76484eb0379e3febe7025a958bb14855107b9ad26daec2fee0119f4');
+    }, 10000);
+});


### PR DESCRIPTION
I changed the EDCSA signing to canonical after discussion in https://github.com/trezor/trezor-crypto/issues/168#issuecomment-408679251 . All the signatures will still be valid, only the new one will be always canonical. 

I also added Signable interface which postpone generating Transaction hash.

And I added Transfer class, which extends Transaction. Nothing is changed about serialising transaction. The information about the transfer is just passed down so Ledger or Trezor integration can build the Payload by itself.